### PR TITLE
JUnit 4.10 modifications

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <packaging>jar</packaging>
 
     <name>JUnit Hierarchical Context Runner</name>
-    <version>4.10.0-SNAPSHOT</version>
+    <version>4.10.0</version>
     <description>
         This is a runner implementation that supports context hierarchies in JUnit. For more
         details please visit: https://github.com/bechte/junit-hierarchicalcontextrunner/wiki
@@ -38,7 +38,7 @@
         <connection>scm:git:git@github.com/bechte/junit-hierarchicalcontextrunner.git</connection>
         <developerConnection>scm:git:git@github.com:bechte/junit-hierarchicalcontextrunner.git</developerConnection>
         <url>git@github.com/bechte/junit-hierarchicalcontextrunner.git</url>
-        <tag>r4.11.3</tag>
+        <tag>r4.10.0</tag>
     </scm>
     <issueManagement>
         <system>github</system>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <packaging>jar</packaging>
 
     <name>JUnit Hierarchical Context Runner</name>
-    <version>4.11.3</version>
+    <version>4.10.0-SNAPSHOT</version>
     <description>
         This is a runner implementation that supports context hierarchies in JUnit. For more
         details please visit: https://github.com/bechte/junit-hierarchicalcontextrunner/wiki
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.10</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
+            <version>1.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/de/bechte/junit/runners/context/HierarchicalContextRunner.java
+++ b/src/main/java/de/bechte/junit/runners/context/HierarchicalContextRunner.java
@@ -88,9 +88,7 @@ public class HierarchicalContextRunner extends Runner {
                 FixtureValidator.AFTER_METHODS,
                 FixtureValidator.TEST_METHODS,
                 RuleValidator.CLASS_RULE_VALIDATOR,
-                RuleValidator.CLASS_RULE_METHOD_VALIDATOR,
-                RuleValidator.RULE_VALIDATOR,
-                RuleValidator.RULE_METHOD_VALIDATOR
+                RuleValidator.RULE_VALIDATOR
         );
     }
 

--- a/src/main/java/de/bechte/junit/runners/context/statements/builder/ClassRuleStatementBuilder.java
+++ b/src/main/java/de/bechte/junit/runners/context/statements/builder/ClassRuleStatementBuilder.java
@@ -19,7 +19,6 @@ public class ClassRuleStatementBuilder implements ClassStatementBuilder {
     public Statement createStatement(final TestClass testClass, final Statement next,
                                      final Description description, final RunNotifier notifier) {
         final List<TestRule> classRules = new ArrayList<TestRule>();
-        classRules.addAll(testClass.getAnnotatedMethodValues(null, ClassRule.class, TestRule.class));
         classRules.addAll(testClass.getAnnotatedFieldValues(null, ClassRule.class, TestRule.class));
         return classRules.isEmpty() ? next : new RunRules(next, classRules, description);
     }

--- a/src/main/java/de/bechte/junit/runners/context/statements/builder/HierarchicalRunRulesStatementBuilder.java
+++ b/src/main/java/de/bechte/junit/runners/context/statements/builder/HierarchicalRunRulesStatementBuilder.java
@@ -31,7 +31,6 @@ public class HierarchicalRunRulesStatementBuilder implements MethodStatementBuil
 
             for (Object instance = target; instance != null; instance = getEnclosingInstance(instance)) {
                 final TestClass instanceTestClass = TestClassPool.forClass(instance.getClass());
-                testRules.addAll(instanceTestClass.getAnnotatedMethodValues(instance, Rule.class, TestRule.class));
                 testRules.addAll(instanceTestClass.getAnnotatedFieldValues(instance, Rule.class, TestRule.class));
                 methodRules.addAll(instanceTestClass.getAnnotatedFieldValues(instance, Rule.class, MethodRule.class));
             }

--- a/src/main/java/de/bechte/junit/runners/validation/RuleValidator.java
+++ b/src/main/java/de/bechte/junit/runners/validation/RuleValidator.java
@@ -12,9 +12,7 @@ import java.util.List;
  */
 public enum RuleValidator implements TestClassValidator {
     CLASS_RULE_VALIDATOR(RuleFieldValidator.CLASS_RULE_VALIDATOR),
-    RULE_VALIDATOR(RuleFieldValidator.RULE_VALIDATOR),
-    CLASS_RULE_METHOD_VALIDATOR(RuleFieldValidator.CLASS_RULE_METHOD_VALIDATOR),
-    RULE_METHOD_VALIDATOR(RuleFieldValidator.RULE_METHOD_VALIDATOR);
+    RULE_VALIDATOR(RuleFieldValidator.RULE_VALIDATOR);
 
     private final RuleFieldValidator validator;
 

--- a/src/test/java/de/bechte/junit/matchers/CollectionMatchers.java
+++ b/src/test/java/de/bechte/junit/matchers/CollectionMatchers.java
@@ -1,0 +1,71 @@
+package de.bechte.junit.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import java.util.*;
+
+/**
+ * This utility class contains several matchers that are not present in hamcrest-1.1.
+ * The implementation is not exactly the same but a minimal one to perform the required tests.
+ */
+public class CollectionMatchers {
+    private CollectionMatchers() { }
+
+    public static <T> Matcher<Collection<? extends T>> empty() {
+        return new TypeSafeMatcher<Collection<? extends T>>() {
+            @Override
+            public boolean matchesSafely(Collection<? extends T> items) {
+                return items.isEmpty();
+            }
+
+            public void describeTo(Description description) {
+                description.appendText("should be empty");
+            }
+        };
+    }
+
+    public static <T> Matcher<List<? extends T>> hasSize(final int expectedSize) {
+        return new TypeSafeMatcher<List<? extends T>>() {
+            @Override
+            public boolean matchesSafely(List<? extends T> items) {
+                return items.size() == expectedSize;
+            }
+
+            public void describeTo(Description description) {
+                description //
+                        .appendText("should have size of: ") //
+                        .appendValue(expectedSize);
+            }
+        };
+    }
+
+    public static <E> Matcher<Collection<E>> emptyCollectionOf(
+            @SuppressWarnings("unused") Class<E> unusedToForceReturnType) {
+        //noinspection unchecked
+        return (Matcher)empty();
+    }
+
+    public static <T> Matcher<Iterable<? extends T>> containsInAnyOrder(final T... expectedTs) {
+        return new TypeSafeMatcher<Iterable<? extends T>>() {
+            @Override
+            public boolean matchesSafely(Iterable<? extends T> ts) {
+                Set<T> tsSet = new HashSet<T>();
+
+                for (T t : ts) {
+                    tsSet.add(t);
+                }
+
+                return tsSet.containsAll(Arrays.asList(expectedTs));
+            }
+
+            public void describeTo(Description description) {
+                description //
+                        .appendText("should contains all of: ") //
+                        .appendValue(expectedTs) //
+                        .appendText(" without specific order");
+            }
+        };
+    }
+}

--- a/src/test/java/de/bechte/junit/runners/context/description/ContextDescriberTest.java
+++ b/src/test/java/de/bechte/junit/runners/context/description/ContextDescriberTest.java
@@ -12,9 +12,12 @@ import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.TestClass;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
-import static org.hamcrest.Matchers.*;
+import static de.bechte.junit.matchers.CollectionMatchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.same;
@@ -50,7 +53,7 @@ public class ContextDescriberTest {
     @Test
     public void whenDescribeIsCalled_descriptionHasTheCorrectTestClass() throws Exception {
         Description description = describer.describe(contextTestClass);
-        assertThat((Class) description.getTestClass(), is(equalTo(contextTestClass)));
+        assertThat(description.getTestClass(), is(equalTo(contextTestClass)));
     }
 
     @Test
@@ -80,7 +83,7 @@ public class ContextDescriberTest {
         TestClass testClass = TestClassPool.forClass(ContextTestClassStub.class);
         when(contextResolver.getChildren(testClass)).thenReturn(contexts);
 
-        when(methodResolver.getChildren(testClass)).thenReturn(Arrays.asList(outerTestMethod));
+        when(methodResolver.getChildren(testClass)).thenReturn(Collections.singletonList(outerTestMethod));
         when(methodDescriber.describe(outerTestMethod)).thenReturn(descriptionOuterTestMethod);
 
         Description description = spiedDescriber.describe(ContextTestClassStub.class);

--- a/src/test/java/de/bechte/junit/runners/context/description/MethodDescriberTest.java
+++ b/src/test/java/de/bechte/junit/runners/context/description/MethodDescriberTest.java
@@ -1,7 +1,6 @@
 package de.bechte.junit.runners.context.description;
 
 import de.bechte.junit.stubs.SimpleTestClassStub;
-import de.bechte.junit.matchers.CollectionMatchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -9,6 +8,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.Description;
 import org.junit.runners.model.FrameworkMethod;
 
+import static de.bechte.junit.matchers.CollectionMatchers.containsInAnyOrder;
 import static de.bechte.junit.matchers.CollectionMatchers.emptyCollectionOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -74,6 +74,6 @@ public class MethodDescriberTest {
     @Test
     public void givenValidMethod_descriptionHasTheCorrectAnnotations() throws Exception {
         Description description = describer.describe(testMethod);
-        assertThat(description.getAnnotations(), CollectionMatchers.containsInAnyOrder(testMethod.getAnnotations()));
+        assertThat(description.getAnnotations(), containsInAnyOrder(testMethod.getAnnotations()));
     }
 }

--- a/src/test/java/de/bechte/junit/runners/context/description/MethodDescriberTest.java
+++ b/src/test/java/de/bechte/junit/runners/context/description/MethodDescriberTest.java
@@ -1,6 +1,7 @@
 package de.bechte.junit.runners.context.description;
 
 import de.bechte.junit.stubs.SimpleTestClassStub;
+import de.bechte.junit.matchers.CollectionMatchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -8,7 +9,9 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.Description;
 import org.junit.runners.model.FrameworkMethod;
 
-import static org.hamcrest.Matchers.*;
+import static de.bechte.junit.matchers.CollectionMatchers.emptyCollectionOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 public class MethodDescriberTest {
@@ -53,7 +56,7 @@ public class MethodDescriberTest {
     @Test
     public void givenValidMethod_descriptionHasTheCorrectTestClass() throws Exception {
         Description description = describer.describe(testMethod);
-        assertThat((Class) description.getTestClass(), is(equalTo(simpleTestClass)));
+        assertThat(description.getTestClass(), is(equalTo(simpleTestClass)));
     }
 
     @Test
@@ -71,6 +74,6 @@ public class MethodDescriberTest {
     @Test
     public void givenValidMethod_descriptionHasTheCorrectAnnotations() throws Exception {
         Description description = describer.describe(testMethod);
-        assertThat(description.getAnnotations(), containsInAnyOrder(testMethod.getAnnotations()));
+        assertThat(description.getAnnotations(), CollectionMatchers.containsInAnyOrder(testMethod.getAnnotations()));
     }
 }

--- a/src/test/java/de/bechte/junit/runners/context/description/SuiteDescriberTest.java
+++ b/src/test/java/de/bechte/junit/runners/context/description/SuiteDescriberTest.java
@@ -14,6 +14,7 @@ import org.junit.runners.model.TestClass;
 import java.util.Arrays;
 import java.util.List;
 
+import static de.bechte.junit.matchers.CollectionMatchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;

--- a/src/test/java/de/bechte/junit/runners/context/processing/ContextResolverTest.java
+++ b/src/test/java/de/bechte/junit/runners/context/processing/ContextResolverTest.java
@@ -7,6 +7,8 @@ import org.junit.runners.model.TestClass;
 
 import java.util.List;
 
+import static de.bechte.junit.matchers.CollectionMatchers.empty;
+import static de.bechte.junit.matchers.CollectionMatchers.hasSize;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
@@ -46,7 +48,8 @@ public class ContextResolverTest {
         TestClass testClass = TestClassPool.forClass(Class1stLevel.class);
         List<Class<?>> children = resolver.getChildren(testClass);
         assertThat(children, hasSize(1));
-        assertThat(children, hasItem(Class1stLevel.Class2ndLevel.class));
+        // java is not recognizing that List implements Iterable in this case
+        assertThat((Iterable)children, hasItem(Class1stLevel.Class2ndLevel.class));
     }
 
     @Test

--- a/src/test/java/de/bechte/junit/runners/context/processing/MethodResolverTest.java
+++ b/src/test/java/de/bechte/junit/runners/context/processing/MethodResolverTest.java
@@ -6,7 +6,7 @@ import org.junit.runners.model.TestClass;
 
 import java.util.List;
 
-import static org.hamcrest.Matchers.empty;
+import static de.bechte.junit.matchers.CollectionMatchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/de/bechte/junit/runners/context/statements/builder/ClassRuleStatementBuilderTest.java
+++ b/src/test/java/de/bechte/junit/runners/context/statements/builder/ClassRuleStatementBuilderTest.java
@@ -37,27 +37,16 @@ public class ClassRuleStatementBuilderTest {
 
     @Test
     public void givenTestClassWithoutRuleAnnotations_returnsNextStatement() throws Exception {
-        when(testClass.getAnnotatedMethodValues(null, ClassRule.class, TestRule.class)).thenReturn(Collections.EMPTY_LIST);
-        when(testClass.getAnnotatedFieldValues(null, ClassRule.class, TestRule.class)).thenReturn(Collections.EMPTY_LIST);
+        when(testClass.getAnnotatedFieldValues(null, ClassRule.class, TestRule.class))
+                .thenReturn(Collections.<TestRule>emptyList());
 
         Statement statement = builder.createStatement(testClass, next, description, notifier);
         assertThat(statement, is(equalTo(next)));
     }
 
     @Test
-    public void givenTestClassWithRuleAnnotatedMethods_returnsRunRulesStatement() throws Exception {
-        List<TestRule> methods = Arrays.asList(rule1, rule2);
-        when(testClass.getAnnotatedMethodValues(null, ClassRule.class, TestRule.class)).thenReturn(methods);
-        when(testClass.getAnnotatedFieldValues(null, ClassRule.class, TestRule.class)).thenReturn(Collections.EMPTY_LIST);
-
-        Statement actual = builder.createStatement(testClass, next, description, notifier);
-        assertThat(actual, is(instanceOf(RunRules.class)));
-    }
-
-    @Test
     public void givenTestClassWithRuleAnnotatedFields_returnsRunRulesStatement() throws Exception {
         List<TestRule> fields = Arrays.asList(rule1, rule2);
-        when(testClass.getAnnotatedMethodValues(null, ClassRule.class, TestRule.class)).thenReturn(Collections.EMPTY_LIST);
         when(testClass.getAnnotatedFieldValues(null, ClassRule.class, TestRule.class)).thenReturn(fields);
 
         Statement actual = builder.createStatement(testClass, next, description, notifier);
@@ -66,9 +55,7 @@ public class ClassRuleStatementBuilderTest {
 
     @Test
     public void givenTestClassWithRuleAnnotatedMethodsAndFields_returnsRunRulesStatement() throws Exception {
-        List<TestRule> methods = Arrays.asList(rule1);
-        List<TestRule> fields = Arrays.asList(rule2);
-        when(testClass.getAnnotatedMethodValues(null, ClassRule.class, TestRule.class)).thenReturn(methods);
+        List<TestRule> fields = Collections.singletonList(rule2);
         when(testClass.getAnnotatedFieldValues(null, ClassRule.class, TestRule.class)).thenReturn(fields);
 
         Statement actual = builder.createStatement(testClass, next, description, notifier);

--- a/src/test/java/de/bechte/junit/runners/validation/BooleanValidatorTest.java
+++ b/src/test/java/de/bechte/junit/runners/validation/BooleanValidatorTest.java
@@ -11,7 +11,7 @@ import org.mockito.Spy;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.Matchers.hasSize;
+import static de.bechte.junit.matchers.CollectionMatchers.hasSize;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.same;

--- a/src/test/java/de/bechte/junit/runners/validation/ChildrenCountValidatorTest.java
+++ b/src/test/java/de/bechte/junit/runners/validation/ChildrenCountValidatorTest.java
@@ -8,6 +8,8 @@ import org.junit.runners.model.TestClass;
 import java.util.ArrayList;
 import java.util.List;
 
+import static de.bechte.junit.matchers.CollectionMatchers.empty;
+import static de.bechte.junit.matchers.CollectionMatchers.hasSize;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 

--- a/src/test/java/de/bechte/junit/runners/validation/ConstructorValidatorTest.java
+++ b/src/test/java/de/bechte/junit/runners/validation/ConstructorValidatorTest.java
@@ -13,11 +13,9 @@ import org.mockito.Spy;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static de.bechte.junit.matchers.CollectionMatchers.hasSize;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;


### PR DESCRIPTION
Hi

I modified the code to support JUnit 4.10.

Why? Because I want to use this wonderful library to build [Atlassian](https://developer.atlassian.com/confdev) plugins; and Atlassian SDK only supports JUnit 4.10.

Most important changes are:
* I created the branch based on tag r4.11.3 and since it is specific for JUnit 4.10 it may be useful that this change lives in its own branch
* Using JUnit 4.10 instead of 4.11, also using Hamcrest 1.1 instead of 1.3
* In JUnit 4.10, @Rule is not supported in methods (this caused compilation errors), so I removed the use of @Rule in methods.
* JUnit 4.10 uses Hamcrest 1.1; some matchers used in tests are missing, so I created them (fortunately they are few)
* Removed a few warnings