### PR TITLE
Issue #33: release automation with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,10 @@
 language: java
-
+jdk:
+  - openjdk7
+jobs:
+  include:
+    - stage: test
+      if: branch != master
+    - stage: release
+      if: branch = master
+      script: mvn -B release:prepare && mvn release:perform


### PR DESCRIPTION
I have a Travis CI sample, but I have two questions that require feedback.

Functional Overview
- non-master branch - Default Travis CI behaviour for Java.  No release.
- master branch - [run Wiki Release HowTo](https://github.com/bechte/junit-hierarchicalcontextrunner/wiki/Release-HowTo) in batch mode.

Issues Found

1. **Compilation with OpenJDK7**
Open Question- Is this the appropriate JDK to build with?
Recommendation - I think OpenJDK7 is appropriate.
Travis CI by default compiles with JDK8 - the build fails on javadoc generation due to a  build due to an error ignored pre-JDK8 ([Background Info](https://stackoverflow.com/questions/15886209/maven-is-not-working-in-java-8-when-javadoc-tags-are-incomplete), [Sample Broken Build](https://travis-ci.org/mouyang/junit-hierarchicalcontextrunner/builds/488669721)).
The project built successfully with JDK7 with no change to the project itself ([Successful Build Sample](https://travis-ci.org/mouyang/junit-hierarchicalcontextrunner/builds/489145834)).  A pre-JDK7 build would require additional Travis configuration (https://docs.travis-ci.com/user/reference/trusty#jvm-clojure-groovy-java-scala-images). 
1. **Release Step Requires GPG Passphrase and Secret Key**
Next Steps - How can a passphrase and secret key be provided?  I’m personally not aware of how to do this.
I was asked for a passphrase in interactive mode, and the build failed in batch mode.  https://travis-ci.org/mouyang/junit-hierarchicalcontextrunner/builds/488674153.  When I provided a dummy passphrase, it proceeded to complain about a missing secret key.

git commit message
- use jdk 7 to bypass javadoc errors without changing the project
- release on master branch, Travis default for other branches