### PR TITLE
Add Android.mk to build for AOSP

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,16 @@
+LOCAL_PATH:= $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := junit-hierarchicalcontextrunner
+
+LOCAL_SRC_FILES := $(call all-java-files-under, src/main/java)
+
+LOCAL_MODULE_TAGS := tests
+
+LOCAL_JAVA_LANGUAGE_VERSION := 1.7
+
+LOCAL_JAVA_LIBRARIES := \
+	junit \
+
+include $(BUILD_STATIC_JAVA_LIBRARY)


### PR DESCRIPTION
I added this (fantastic !) project to my AOSP tree under external/junit-hierarchicalcontextrunner in order to build nicely formatted unit tests for my AOSP device. All it needed was a standard Android.mk.